### PR TITLE
Fixing for Boot2Docker 1.7.1

### DIFF
--- a/lib/bigrig/waiter.rb
+++ b/lib/bigrig/waiter.rb
@@ -7,7 +7,7 @@ module Bigrig
     def wait_if_needed
       script_present? || return
       puts "Waiting for `/bigrig-wait.sh` to compelte on #{@name}"
-      result = DockerAdapter.exec @name, '/bigrig-wait.sh'
+      result = DockerAdapter.exec @name, ['/bigrig-wait.sh']
       result[2] != 0 && fail("Error waiting for container: #{result.first.first}")
     end
 


### PR DESCRIPTION
Current version of bigrig blows up with:
```bash
json: cannot unmarshal string into Go value of type []string
```

The fix was to just send the exec command always as an array. This is really a bug with the underlying api but we can also fix it here.